### PR TITLE
db-config for prod

### DIFF
--- a/.deploy/dev-gcp-teamforeldrepenger.json
+++ b/.deploy/dev-gcp-teamforeldrepenger.json
@@ -3,7 +3,7 @@
     "kafkaPool": "nav-dev",
     "dbTier": "db-f1-micro",
     "dbDiskAutoresize": "false",
-    "dbHighAvilability": "false",
+    "dbHighAvailability": "false",
     "dbPointInTimeRecovery": "false",
     "minReplicas": "2",
     "maxReplicas": "2",

--- a/.deploy/dev-gcp-teamforeldrepenger.json
+++ b/.deploy/dev-gcp-teamforeldrepenger.json
@@ -1,7 +1,10 @@
 {
     "environment": "dev",
     "kafkaPool": "nav-dev",
-    "dbtier": "db-f1-micro",
+    "dbTier": "db-f1-micro",
+    "dbDiskAutoresize": "false",
+    "dbHighAvilability": "false",
+    "dbPointInTimeRecovery": "false",
     "minReplicas": "2",
     "maxReplicas": "2",
     "ingresses": [

--- a/.deploy/naiserator.yaml
+++ b/.deploy/naiserator.yaml
@@ -45,7 +45,10 @@ spec:
       - type: POSTGRES_14
         databases:
           - name: fpoversikt
-        tier: {{dbtier}}
+        tier: {{dbTier}}
+        diskAutoresize: {{dbDiskAutoresize}}
+        highAvailability: {{dbHighAvailability}}
+        pointInTimeRecovery: {{dbPointInTimeRecovery}}
         collation: nb_NO.UTF8
   tokenx:
     enabled: true

--- a/.deploy/prod-gcp-teamforeldrepenger.json
+++ b/.deploy/prod-gcp-teamforeldrepenger.json
@@ -3,7 +3,7 @@
     "kafkaPool": "nav-prod",
     "dbTier": "db-custom-1-1024",
     "dbDiskAutoresize": "true",
-    "dbHighAvilability": "true",
+    "dbHighAvailability": "true",
     "dbPointInTimeRecovery": "true",
     "minReplicas": "2",
     "maxReplicas": "3",

--- a/.deploy/prod-gcp-teamforeldrepenger.json
+++ b/.deploy/prod-gcp-teamforeldrepenger.json
@@ -1,7 +1,10 @@
 {
     "environment": "prod",
     "kafkaPool": "nav-prod",
-    "dbtier": "finnriktigsize",
+    "dbTier": "db-custom-1-1024",
+    "dbDiskAutoresize": "true",
+    "dbHighAvilability": "true",
+    "dbPointInTimeRecovery": "true",
     "minReplicas": "2",
     "maxReplicas": "3",
     "ingresses": [


### PR DESCRIPTION
Starter med 1 cpu og 1 gig med ram. Ved behov kan vi øke, men krever nedetid.

Om pointInTimeRecovery: ser noen kjører uten. Tror true er default i prod, men jeg legger til eksplisitt ettersom jeg er usikker på om vi behøver i dev. Se ellers https://cloud.google.com/sql/docs/postgres/backup-recovery/pitr 
SSD er default=true. Legger ikke til eksplisitt config av det.