### PR TITLE
Ignorer journalposter som gjelder infotrygd

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/oversikt/arkiv/EnkelJournalpost.java
+++ b/src/main/java/no/nav/foreldrepenger/oversikt/arkiv/EnkelJournalpost.java
@@ -4,6 +4,7 @@ package no.nav.foreldrepenger.oversikt.arkiv;
 import no.nav.foreldrepenger.common.domain.felles.DokumentType;
 
 public record EnkelJournalpost(String journalpostId,
+                               String fagsaksystem,
                                String eksternReferanse,
                                String saksnummer,
                                Type type,
@@ -12,6 +13,10 @@ public record EnkelJournalpost(String journalpostId,
     public enum Type {
         INNGÅENDE_DOKUMENT,
         UTGÅENDE_DOKUMENT
+    }
+
+    public boolean erInfotrygdSak() {
+        return "IT01".equalsIgnoreCase(fagsaksystem);
     }
 
     public record Bruker(Type type, String ident) {

--- a/src/main/java/no/nav/foreldrepenger/oversikt/arkiv/SafTjeneste.java
+++ b/src/main/java/no/nav/foreldrepenger/oversikt/arkiv/SafTjeneste.java
@@ -60,7 +60,7 @@ public class SafTjeneste {
             .journalposttype()
             .eksternReferanseId()
             .bruker(new BrukerResponseProjection().type().id())
-            .sak(new SakResponseProjection().fagsakId())
+            .sak(new SakResponseProjection().fagsakId().fagsaksystem())
             .tilleggsopplysninger(new TilleggsopplysningResponseProjection().nokkel().verdi())
             .dokumenter(new DokumentInfoResponseProjection().tittel());
     }
@@ -69,6 +69,7 @@ public class SafTjeneste {
         var innsendingstype = tilType(journalpost.getJournalposttype());
         return new EnkelJournalpost(
             journalpost.getJournalpostId(),
+            journalpost.getSak().getFagsaksystem(),
             journalpost.getEksternReferanseId(),
             journalpost.getSak().getFagsakId(),
             innsendingstype,

--- a/src/main/java/no/nav/foreldrepenger/oversikt/innhenting/journalføringshendelse/JournalføringHendelseTaskUtleder.java
+++ b/src/main/java/no/nav/foreldrepenger/oversikt/innhenting/journalføringshendelse/JournalføringHendelseTaskUtleder.java
@@ -42,7 +42,7 @@ public class JournalføringHendelseTaskUtleder {
     List<ProsessTaskData> utledProsesstask(EnkelJournalpost journalpost) {
         var saksnummer = journalpost.saksnummer();
         var dokumenttype = journalpost.hovedtype();
-        if (dokumenttype == null) {
+        if (dokumenttype == null || journalpost.erInfotrygdSak()) {
             return List.of();
         }
 

--- a/src/test/java/no/nav/foreldrepenger/oversikt/innhenting/journalføringshendelse/JournalføringHendelseTaskUtlederTest.java
+++ b/src/test/java/no/nav/foreldrepenger/oversikt/innhenting/journalføringshendelse/JournalføringHendelseTaskUtlederTest.java
@@ -81,6 +81,7 @@ class JournalføringHendelseTaskUtlederTest {
     private static EnkelJournalpost søknad() {
         return new EnkelJournalpost(
             "123",
+            "FS36",
             UUID.randomUUID().toString(),
             Saksnummer.dummy().value(),
             EnkelJournalpost.Type.INNGÅENDE_DOKUMENT,
@@ -92,6 +93,7 @@ class JournalføringHendelseTaskUtlederTest {
     private static EnkelJournalpost ettersending() {
         return new EnkelJournalpost(
             "123",
+            "FS36",
             UUID.randomUUID().toString(),
             Saksnummer.dummy().value(),
             EnkelJournalpost.Type.INNGÅENDE_DOKUMENT,
@@ -103,6 +105,7 @@ class JournalføringHendelseTaskUtlederTest {
     private static EnkelJournalpost inntektsmelding() {
         return new EnkelJournalpost(
             "123",
+            "FS36",
             UUID.randomUUID().toString(),
             Saksnummer.dummy().value(),
             EnkelJournalpost.Type.INNGÅENDE_DOKUMENT,
@@ -114,6 +117,7 @@ class JournalføringHendelseTaskUtlederTest {
     private static EnkelJournalpost uttalelseTilbakebetaling() {
         return new EnkelJournalpost(
             "123",
+            "FS36",
             UUID.randomUUID().toString(),
             Saksnummer.dummy().value(),
             EnkelJournalpost.Type.INNGÅENDE_DOKUMENT,


### PR DESCRIPTION
Vi tilbyr ikke innsyn for infotrygd selv om det gjelder foreldrepenger. Bare gjør en enkel sjekk på fagsystemkoden for infotrygd IT01 for å skippe journalpostene. 

Ref https://nav-it.slack.com/archives/C60FFACN5/p1692010193590259?thread_ts=1691998194.902179&cid=C60FFACN5