### PR TITLE
Cache oppslag av personnavn ved systemkall (TFP-6297)

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/oversikt/integrasjoner/pdl/PdlKlientSystem.java
+++ b/src/main/java/no/nav/foreldrepenger/oversikt/integrasjoner/pdl/PdlKlientSystem.java
@@ -38,6 +38,7 @@ public class PdlKlientSystem extends AbstractPersonKlient implements PersonOppsl
     private static final LRUCache<String, Fødselsnummer> AKTØR_FNR = new LRUCache<>(2000, CACHE_ELEMENT_LIVE_TIME_MS);
     private static final LRUCache<String, AktørId> FNR_AKTØR = new LRUCache<>(2000, CACHE_ELEMENT_LIVE_TIME_MS);
     private static final LRUCache<String, AdresseBeskyttelse> FNR_ADRESSE = new LRUCache<>(2000, CACHE_ELEMENT_LIVE_TIME_MS);
+    private static final LRUCache<String, String> IDENT_NAVN = new LRUCache<>(2000, CACHE_ELEMENT_LIVE_TIME_MS);
 
     @Override
     public Fødselsnummer fødselsnummer(AktørId aktørId) {
@@ -86,6 +87,9 @@ public class PdlKlientSystem extends AbstractPersonKlient implements PersonOppsl
 
     @Override
     public String navn(String ident) {
+        if (IDENT_NAVN.get(ident) != null) {
+            return IDENT_NAVN.get(ident);
+        }
         var request = new HentPersonQueryRequest();
         request.setIdent(ident);
         var projection = new PersonResponseProjection()
@@ -95,10 +99,12 @@ public class PdlKlientSystem extends AbstractPersonKlient implements PersonOppsl
         if (person == null) {
             return "Ukjent person";
         }
-        return person.getNavn().stream()
+        var navn = person.getNavn().stream()
             .map(PdlKlientSystem::mapNavn)
             .filter(Objects::nonNull)
             .findFirst().orElse("Ukjent navn");
+        IDENT_NAVN.put(ident, navn);
+        return navn;
     }
 
     @Override

--- a/src/main/java/no/nav/foreldrepenger/oversikt/oppslag/MineArbeidsforholdTjeneste.java
+++ b/src/main/java/no/nav/foreldrepenger/oversikt/oppslag/MineArbeidsforholdTjeneste.java
@@ -111,7 +111,7 @@ public class MineArbeidsforholdTjeneste {
         return interval.overlaps(new LocalDateInterval(LocalDate.now(), LocalDate.now()));
     }
 
-    private String tilArbeidsgiverTypeFrontend(ArbeidsforholdIdentifikator a) {
+    private static String tilArbeidsgiverTypeFrontend(ArbeidsforholdIdentifikator a) {
         if (VirksomhetTjeneste.erOrganisasjonsNummer(a.arbeidsgiver())) {
             return "orgnr";
         } else if (erIdent(a.arbeidsgiver())) {


### PR DESCRIPTION
Ser tilfeller av kall til /rest/sokerinfo som timer ut mot fpoversikt når bruker har flere personarbeidsgivere. Her hentes det ut store mengder arbeidsforhold pga forenklet oppgjørsordning. Deretter gjøres det voldsomt mange kall mot PDL for å slå opp navn for samme person. Foreslår enkel løsning med caching av kallet som gjøres i systemkontekst.