### PR TITLE
TFP-6872 oppsett for info om selvstendig næring

### DIFF
--- a/.deploy/naiserator.yaml
+++ b/.deploy/naiserator.yaml
@@ -80,6 +80,11 @@ spec:
           {{#each groups as |group|}}
              - id: "{{group.uuid}}"
          {{/each}}
+  maskinporten:
+    enabled: true
+    scopes:
+      consumes:
+        - name: "brreg:data:enhetsregisteret:roller:person:oppslag:fnr"
   observability:
     autoInstrumentation:
       enabled: true
@@ -124,3 +129,4 @@ spec:
         - host: fptilbake.{{environment}}-fss-pub.nais.io
         - host: saf.{{environment}}-fss-pub.nais.io
         - host: safselvbetjening.{{environment}}-fss-pub.nais.io
+        - host: data.brreg.no

--- a/src/main/java/no/nav/foreldrepenger/oversikt/integrasjoner/brreg/BrregEnhetDto.java
+++ b/src/main/java/no/nav/foreldrepenger/oversikt/integrasjoner/brreg/BrregEnhetDto.java
@@ -1,0 +1,28 @@
+package no.nav.foreldrepenger.oversikt.integrasjoner.brreg;
+
+import java.time.LocalDate;
+
+public record BrregEnhetDto(String organisasjonsnummer,
+                            String navn,
+                            EnhetKodeDto organisasjonsform,
+                            EnhetKodeDto naeringskode1,
+                            EnhetKodeDto naeringskode2,
+                            EnhetKodeDto naeringskode3,
+                            Boolean underAvvikling,
+                            String overordnetEnhet,
+                            LocalDate stiftelsesdato,
+                            LocalDate registreringsdatoEnhetsregisteret,
+                            EnhetLinksDto _links) {
+
+    public record EnhetLinksDto(EnhetLinkDto self, EnhetLinkDto overordnetEnhet) {}
+
+    public record EnhetLinkDto(String href) {}
+
+    public record EnhetKodeDto(String kode, String beskrivelse) {}
+
+    @Override
+    public String toString() {
+        return "BrregEnhetDto{" + "organisasjonsnummer='" + organisasjonsnummer + '\'' + ", organisasjonsform=" + organisasjonsform
+            + ", overordnetEnhet='" + overordnetEnhet + '\'' + ", _links=" + _links + '}';
+    }
+}

--- a/src/main/java/no/nav/foreldrepenger/oversikt/integrasjoner/brreg/BrregRollerMapper.java
+++ b/src/main/java/no/nav/foreldrepenger/oversikt/integrasjoner/brreg/BrregRollerMapper.java
@@ -20,12 +20,10 @@ public class BrregRollerMapper {
     static BrregSelvstendigNæring mapSelvstendigNæring(BrregRolleutskriftDto.EnhetDto enhet, BrregEnhetDto enhetsdata) {
         var relevanteRoller = rollerForSelvstendigNæringsdrivende(enhet);
         var enhetsinfo = Optional.ofNullable(enhetsdata);
-        var virksomhetType = enhetsinfo.map(BrregRollerMapper::utledVirksomhetType).orElse(VirksomhetType.ANNEN);
-        var enhetsNavn = enhetsinfo.map(BrregEnhetDto::navn).orElse("Ukjent navn");
-        var orgformKode = enhetsinfo.map(BrregEnhetDto::organisasjonsform).map(BrregEnhetDto.EnhetKodeDto::kode).orElse("Ukjent");
-        var orgformBeskrivelse = enhetsinfo.map(BrregEnhetDto::organisasjonsform).map(BrregEnhetDto.EnhetKodeDto::kode).orElse("Ukjent");
-        return new BrregSelvstendigNæring(enhet.organisasjonsnummer(), enhetsNavn,
-            orgformKode, orgformBeskrivelse, virksomhetType,
+        return new BrregSelvstendigNæring(enhet.organisasjonsnummer(), enhetsinfo.map(BrregEnhetDto::navn).orElse(null),
+            enhetsinfo.map(BrregEnhetDto::organisasjonsform).map(BrregEnhetDto.EnhetKodeDto::kode).orElse(null),
+            enhetsinfo.map(BrregEnhetDto::organisasjonsform).map(BrregEnhetDto.EnhetKodeDto::kode).orElse(null),
+            enhetsinfo.map(BrregRollerMapper::utledVirksomhetType).orElse(VirksomhetType.ANNEN),
             enhetsinfo.map(BrregEnhetDto::underAvvikling).orElse(false),
             enhetsinfo.map(BrregEnhetDto::stiftelsesdato).orElse(null),
             enhetsinfo.map(BrregEnhetDto::registreringsdatoEnhetsregisteret).orElse(null),

--- a/src/main/java/no/nav/foreldrepenger/oversikt/integrasjoner/brreg/BrregRollerMapper.java
+++ b/src/main/java/no/nav/foreldrepenger/oversikt/integrasjoner/brreg/BrregRollerMapper.java
@@ -1,0 +1,71 @@
+package no.nav.foreldrepenger.oversikt.integrasjoner.brreg;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class BrregRollerMapper {
+
+    private static final Map<String, SNRolleType> SN_ROLLER = Arrays.stream(SNRolleType.values())
+        .collect(Collectors.toMap(SNRolleType::getKode, Function.identity()));
+
+    private BrregRollerMapper() {
+    }
+
+
+    static BrregSelvstendigNæring mapSelvstendigNæring(BrregRolleutskriftDto.EnhetDto enhet, BrregEnhetDto enhetsdata) {
+        var relevanteRoller = rollerForSelvstendigNæringsdrivende(enhet);
+        var enhetsinfo = Optional.ofNullable(enhetsdata);
+        var virksomhetType = enhetsinfo.map(BrregRollerMapper::utledVirksomhetType).orElse(VirksomhetType.ANNEN);
+        var enhetsNavn = enhetsinfo.map(BrregEnhetDto::navn).orElse("Ukjent navn");
+        var orgformKode = enhetsinfo.map(BrregEnhetDto::organisasjonsform).map(BrregEnhetDto.EnhetKodeDto::kode).orElse("Ukjent");
+        var orgformBeskrivelse = enhetsinfo.map(BrregEnhetDto::organisasjonsform).map(BrregEnhetDto.EnhetKodeDto::kode).orElse("Ukjent");
+        return new BrregSelvstendigNæring(enhet.organisasjonsnummer(), enhetsNavn,
+            orgformKode, orgformBeskrivelse, virksomhetType,
+            enhetsinfo.map(BrregEnhetDto::underAvvikling).orElse(false),
+            enhetsinfo.map(BrregEnhetDto::stiftelsesdato).orElse(null),
+            enhetsinfo.map(BrregEnhetDto::registreringsdatoEnhetsregisteret).orElse(null),
+            relevanteRoller);
+    }
+
+    static boolean erSelvstendigNæringsdrivende(BrregRolleutskriftDto.EnhetDto enhet) {
+        return !rollerForSelvstendigNæringsdrivende(enhet).isEmpty();
+    }
+
+    private static List<SNRolleType> rollerForSelvstendigNæringsdrivende(BrregRolleutskriftDto.EnhetDto enhet) {
+        return enhet.roller().stream()
+            .map(BrregRolleutskriftDto.RolleDto::type)
+            .filter(Objects::nonNull)
+            .map(BrregRolleutskriftDto.RolleKodeDto::kode)
+            .filter(Objects::nonNull)
+            .map(SN_ROLLER::get)
+            .filter(Objects::nonNull)
+            .toList();
+    }
+
+    private static VirksomhetType utledVirksomhetType(BrregEnhetDto enhet) {
+        if (enhet.naeringskode1() == null || enhet.naeringskode1().kode() == null) {
+            return VirksomhetType.ANNEN;
+        }
+        var næringskode = enhet.naeringskode1().kode();
+        if (næringskode.startsWith("01")) {
+            return næringskode.startsWith("01.6") || næringskode.startsWith("01.7") ?
+                VirksomhetType.ANNEN : VirksomhetType.JORDBRUK_SKOGBRUK;
+        } else if (næringskode.startsWith("02.1")) {
+            return VirksomhetType.JORDBRUK_SKOGBRUK;
+        } else if (næringskode.startsWith("03.1")) {
+            return VirksomhetType.FISKE_FANGST;
+        } else if (næringskode.startsWith("88.91")) {
+            return VirksomhetType.DAGMAMMA;
+        } else {
+            return VirksomhetType.ANNEN;
+        }
+    }
+
+
+
+}

--- a/src/main/java/no/nav/foreldrepenger/oversikt/integrasjoner/brreg/BrregRollerTjeneste.java
+++ b/src/main/java/no/nav/foreldrepenger/oversikt/integrasjoner/brreg/BrregRollerTjeneste.java
@@ -1,0 +1,135 @@
+package no.nav.foreldrepenger.oversikt.integrasjoner.brreg;
+
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriBuilder;
+import no.nav.foreldrepenger.konfig.Environment;
+import no.nav.foreldrepenger.kontrakter.felles.typer.Fødselsnummer;
+import no.nav.vedtak.exception.IntegrasjonException;
+import no.nav.vedtak.felles.integrasjon.rest.RestClient;
+import no.nav.vedtak.felles.integrasjon.rest.RestClientConfig;
+import no.nav.vedtak.felles.integrasjon.rest.RestConfig;
+import no.nav.vedtak.felles.integrasjon.rest.RestRequest;
+import no.nav.vedtak.felles.integrasjon.rest.TokenFlow;
+import no.nav.vedtak.sikkerhet.oidc.token.impl.MaskinportenTokenKlient;
+import no.nav.vedtak.util.LRUCache;
+
+@Dependent // Vennligst la denne henge under en ApplicationScoped så cache blir værende
+@RestClientConfig(tokenConfig = TokenFlow.NO_AUTH_NEEDED, endpointProperty = "brreg.direct.url", endpointDefault = "https://data.brreg.no/enhetsregisteret")
+public class BrregRollerTjeneste {
+
+    private static final Environment ENV = Environment.current();
+    private static final Logger LOG = LoggerFactory.getLogger(BrregRollerTjeneste.class);
+
+    private static final String AUTORISERT_API = "/autorisert-api";
+
+    private static final String ROLLEUTSKRIFT_SCOPE = "brreg:data:enhetsregisteret:roller:person:oppslag:fnr";
+    private static final String ROLLEUTSKRIFT_URL = AUTORISERT_API + "/personer/rolleutskrift";
+
+    private static final long CACHE_ELEMENT_LIVE_TIME_MS = TimeUnit.MILLISECONDS.convert(1, TimeUnit.HOURS);
+    private static final LRUCache<String, BrregEnhetDto> CACHE_ENHET = new LRUCache<>(200, CACHE_ELEMENT_LIVE_TIME_MS);
+    private static final LRUCache<String, List<BrregRolleutskriftDto.EnhetDto>> CACHE_ROLLEUTSKRIFT = new LRUCache<>(100, CACHE_ELEMENT_LIVE_TIME_MS);
+
+    private final RestClient sender;
+    private final RestConfig restConfig;
+    private final String maskinportenResource;
+    private final URI rolleutskriftEndpoint;
+    private MaskinportenTokenKlient tokenKlient;
+
+    public BrregRollerTjeneste() {
+        this(RestClient.client(), RestConfig.forClient(BrregRollerTjeneste.class));
+    }
+
+    public BrregRollerTjeneste(RestClient sender, RestConfig config) {
+        this.restConfig = config;
+        this.sender = sender;
+        this.maskinportenResource = restConfig.endpoint().toString() + AUTORISERT_API; // annen ressurs for bruk i preprod
+        this.rolleutskriftEndpoint = UriBuilder.fromUri(restConfig.endpoint()).path(ROLLEUTSKRIFT_URL).build();
+        this.tokenKlient = null;
+    }
+
+    public List<BrregSelvstendigNæring> finnSelvstendigNæring(Fødselsnummer fødselsnummer) {
+        return hentRollerForPerson(fødselsnummer).stream()
+            .map(this::finnSelvstendigNæring)
+            .toList();
+    }
+
+    private BrregSelvstendigNæring finnSelvstendigNæring(BrregRolleutskriftDto.EnhetDto enhet) {
+        var enhetsdata = Optional.ofNullable(enhet._links())
+            .map(BrregRolleutskriftDto.LinksDto::enhet)
+            .map(BrregRolleutskriftDto.LinkDto::href)
+            .map(URI::create)
+            .flatMap(uri -> finnEnhetsinfoFraLink(enhet.organisasjonsnummer(), uri))
+            .orElse(null);
+        return BrregRollerMapper.mapSelvstendigNæring(enhet, enhetsdata);
+    }
+
+    public Optional<BrregEnhetDto> finnEnhetsinfoFraLink(String orgnummer, URI target) {
+        if (!ENV.isProd()) {
+            return Optional.empty();
+        }
+        if (orgnummer != null && CACHE_ENHET.get(orgnummer) != null) {
+            return Optional.ofNullable(CACHE_ENHET.get(orgnummer));
+        }
+        try {
+            var request = RestRequest.newGET(target, restConfig);
+            var respons = sender.sendReturnOptional(request, BrregEnhetDto.class);
+            respons.ifPresent(r -> CACHE_ENHET.put(r.organisasjonsnummer(), r));
+            return respons;
+        } catch (Exception e) {
+            LOG.warn("FPRISK Uvanlig feil ved kall mot brreg direkte enhetslink for {}. Fikk feilmelding: ", target, e);
+            return Optional.empty();
+        }
+    }
+
+    public List<BrregRolleutskriftDto.EnhetDto> hentRollerForPerson(Fødselsnummer fødselsnummer) {
+        if (!ENV.isProd() || fødselsnummer.value() == null) {
+            return List.of();
+        }
+        if (CACHE_ROLLEUTSKRIFT.get(fødselsnummer.value()) != null) {
+            return CACHE_ROLLEUTSKRIFT.get(fødselsnummer.value());
+        }
+        if (tokenKlient == null) {
+            tokenKlient = MaskinportenTokenKlient.instance();
+        }
+        var respons = gjørPersonKallTilBrreg(fødselsnummer);
+        var resultat = respons.map(BrregRolleutskriftDto::enheter).orElse(List.of()).stream()
+            .filter(BrregRollerMapper::erSelvstendigNæringsdrivende)
+            .toList();
+        LOG.info("FPRISK vellykket kall mot brreg direkte rolleutskrift. Fikk {}", resultat.size());
+        CACHE_ROLLEUTSKRIFT.put(fødselsnummer.value(), resultat);
+        return resultat;
+    }
+
+    private Optional<BrregRolleutskriftDto> gjørPersonKallTilBrreg(Fødselsnummer fødselsnummer) {
+        try {
+            var method = new RestRequest.Method(RestRequest.WebMethod.POST, HttpRequest.BodyPublishers.ofString(fødselsnummer.value()));
+            var request = RestRequest.newRequest(method, rolleutskriftEndpoint, restConfig)
+                .setAndReplaceHeader(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_PLAIN)
+                .otherAuthorizationSupplier(() -> tokenKlient.hentMaskinportenToken(ROLLEUTSKRIFT_SCOPE, maskinportenResource).token());
+            return sender.sendReturnOptional(request, BrregRolleutskriftDto.class);
+        } catch (Exception e) {
+            if (e instanceof IntegrasjonException ie && Response.Status.NOT_FOUND.getStatusCode() == ie.getStatusCode()) {
+                return Optional.empty();
+            } else {
+                var ie = e.getMessage();
+                var vasketFeil = ie.replace(fødselsnummer.value(), fødselsnummer.toString());
+                LOG.info("Kall mot brreg direkte rolleutskrift feilet. Fikk feilmelding: {}", vasketFeil);
+                return Optional.empty();
+            }
+        }
+    }
+
+
+}

--- a/src/main/java/no/nav/foreldrepenger/oversikt/integrasjoner/brreg/BrregRolleutskriftDto.java
+++ b/src/main/java/no/nav/foreldrepenger/oversikt/integrasjoner/brreg/BrregRolleutskriftDto.java
@@ -1,0 +1,23 @@
+package no.nav.foreldrepenger.oversikt.integrasjoner.brreg;
+
+import java.util.List;
+
+public record BrregRolleutskriftDto(List<EnhetDto> enheter) {
+
+    public record EnhetDto(String organisasjonsnummer, String navn, List<RolleDto> roller, LinksDto _links) {
+    }
+
+    public record RolleDto(Boolean fratraadt, Boolean avregistrert, RolleKodeDto type) {
+    }
+
+    public record RolleKodeDto(String kode, String beskrivelse) {
+    }
+
+    public record LinksDto(LinkDto enhet) {
+    }
+
+    public record LinkDto(String href) {
+    }
+
+
+}

--- a/src/main/java/no/nav/foreldrepenger/oversikt/integrasjoner/brreg/BrregSelvstendigNæring.java
+++ b/src/main/java/no/nav/foreldrepenger/oversikt/integrasjoner/brreg/BrregSelvstendigNæring.java
@@ -1,0 +1,21 @@
+package no.nav.foreldrepenger.oversikt.integrasjoner.brreg;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record BrregSelvstendigNæring(String organisasjonsnummer,
+                                     String navn,
+                                     String organisasjonsformKode,
+                                     String organisasjonsformBeskrivelse,
+                                     VirksomhetType virksomhetType,
+                                     Boolean underAvvikling,
+                                     LocalDate stiftelsesdato,
+                                     LocalDate registreringsdatoEnhetsregisteret,
+                                     List<SNRolleType> roller) {
+
+
+    @Override
+    public String toString() {
+        return "BrregEnhetDto{" + "organisasjonsnummer='" + organisasjonsnummer + '\'' + ", organisasjonsform=" + organisasjonsformKode + '}';
+    }
+}

--- a/src/main/java/no/nav/foreldrepenger/oversikt/integrasjoner/brreg/SNRolleType.java
+++ b/src/main/java/no/nav/foreldrepenger/oversikt/integrasjoner/brreg/SNRolleType.java
@@ -1,0 +1,21 @@
+package no.nav.foreldrepenger.oversikt.integrasjoner.brreg;
+
+public enum SNRolleType {
+
+    INNEHAVER("INNH"),
+    DELTAKER_PRORATA("DTPR"), // Delt ansvar i ANS,DA,KS
+    DELTAKER_SOLIDARISK("DTSO"), // Fullt ansvar i ANS, DA KS
+    KOMPLEMENTAR("KOMP"), // KS ubegrenset ansvar
+    KONKURS("KENK") // Den personlige konkursen angår
+    ;
+
+    private final String kode;
+
+    SNRolleType(String kode) {
+        this.kode = kode;
+    }
+
+    public String getKode() {
+        return kode;
+    }
+}

--- a/src/main/java/no/nav/foreldrepenger/oversikt/integrasjoner/brreg/VirksomhetType.java
+++ b/src/main/java/no/nav/foreldrepenger/oversikt/integrasjoner/brreg/VirksomhetType.java
@@ -1,0 +1,10 @@
+package no.nav.foreldrepenger.oversikt.integrasjoner.brreg;
+
+public enum VirksomhetType {
+
+    DAGMAMMA,
+    FISKE_FANGST,
+    JORDBRUK_SKOGBRUK,
+    ANNEN,
+    ;
+}

--- a/src/main/resources/application-vtp.properties
+++ b/src/main/resources/application-vtp.properties
@@ -51,6 +51,8 @@ krr.rs.scopes=api://vtp.teamforeldrepenger.vtp/.default
 sokos.kontoregister.person.url=http://localhost:8060/rest/dummy/oppslag
 sokos.kontoregister.person.rs.scopes=api://vtp.teamforeldrepenger.vtp/.default
 
+brreg.direct.url=http://localhost:8060/rest/dummy/brreg
+
 kafka.topic.minside.brukervarsel=ikkebrukt
 
 DB_JDBC_URL=jdbc:postgresql://localhost:5999/fpoversikt?password=fpoversikt&user=fpoversikt

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,6 +2,7 @@
 application.name=fpoversikt
 context.path=/fpoversikt
 
+brreg.direct.url= https://data.brreg.no/enhetsregisteret
 
 kafka.topic.journal.hendelse=teamdokumenthandtering.aapen-dok-journalfoering
 


### PR DESCRIPTION
Denne henter roller fra BRreg, finner enheter som kvalifiserer som selvstendig næring jfr skattelovgivning.
Henter deretter navn, næring mm fra BRreg for å klassifisere virksomheten - ref skattetrekk til OS.
Dette er bare grunnkoden og den er ikke koblet opp mot søknaden ennå - men bør gi riktig svar på om søker er selvstendig næringsdrivende, med orgnummer, navn, roller og virksomhetstype.
Det bør antagelig skrives en brreg-mock i VTP i løpet av prosessen.
BRreg-tjenesten har vært validert tidligere så dette kan ses som en prod-først