### PR TITLE
Chore: fjern BehandlingTilstand.PROSESSERER og bump fp-kontrakter til…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
         <felles.version>7.8.3</felles.version>
         <prosesstask.version>5.2.7</prosesstask.version>
-        <fp-kontrakter.version>9.4.36</fp-kontrakter.version>
+        <fp-kontrakter.version>9.4.37</fp-kontrakter.version>
         <fp-tidsserie.version>2.7.4</fp-tidsserie.version>
         <mittnav-varsler.version>2.2.0</mittnav-varsler.version>
         <teamdokumenthandtering-avro-schemas.version>1.1.6</teamdokumenthandtering-avro-schemas.version>

--- a/src/main/java/no/nav/foreldrepenger/oversikt/domene/BehandlingTilstandUtleder.java
+++ b/src/main/java/no/nav/foreldrepenger/oversikt/domene/BehandlingTilstandUtleder.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.oversikt.domene;
 
-import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.Set;
@@ -10,32 +9,26 @@ import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import no.nav.foreldrepenger.konfig.Environment;
 import no.nav.foreldrepenger.kontrakter.fpoversikt.BehandlingTilstand;
 
 public final class BehandlingTilstandUtleder {
 
     private static final Logger LOG = LoggerFactory.getLogger(BehandlingTilstandUtleder.class);
-    private static final int SEKUNDER_VENTETID_PÅ_PROSESSERING_AV_SØKNAD = 15;
-    private static final Environment ENV = Environment.current();
 
     private BehandlingTilstandUtleder() {
     }
 
-    public static BehandlingTilstand utled(Set<Aksjonspunkt> ap, LocalDateTime søknadMottattTidspunkt) {
+    public static BehandlingTilstand utled(Set<Aksjonspunkt> ap) {
 
         var aksjonspunkt = Stream.ofNullable(ap)
             .flatMap(Collection::stream)
             .collect(Collectors.toSet());
-        var tilstand = utledGittOpprettetAksjonspunkt(aksjonspunkt, søknadMottattTidspunkt);
-        LOG.info("Utledet behandlingtilstand {} for aksjonspunkter {} søknad mottatt {}", tilstand, aksjonspunkt, søknadMottattTidspunkt);
-        if (tilstand == BehandlingTilstand.PROSESSERER && ENV.isProd()) {
-            return BehandlingTilstand.UNDER_BEHANDLING; // TODO TFP-5621 Til frontend er over på ny status
-        }
+        var tilstand = utledGittOpprettetAksjonspunkt(aksjonspunkt);
+        LOG.info("Utledet behandlingtilstand {} for aksjonspunkter {}", tilstand, aksjonspunkt);
         return tilstand;
     }
 
-    private static BehandlingTilstand utledGittOpprettetAksjonspunkt(Set<Aksjonspunkt> opprettetAksjonspunkt, LocalDateTime søknadMottattTidspunkt) {
+    private static BehandlingTilstand utledGittOpprettetAksjonspunkt(Set<Aksjonspunkt> opprettetAksjonspunkt) {
         if (contains(opprettetAksjonspunkt, Aksjonspunkt.Type.VENT_TIDLIG_SØKNAD)) {
             return BehandlingTilstand.VENT_TIDLIG_SØKNAD;
         }
@@ -49,13 +42,6 @@ public final class BehandlingTilstandUtleder {
             return BehandlingTilstand.VENT_INNTEKTSMELDING;
         }
         // TODO utvid med tilstand VENT_UTLAND_TRYGD basert på venteårsak UTLAND_TRYGD
-        if (opprettetAksjonspunkt.isEmpty()) {
-            if (søknadMottattTidspunkt.plusSeconds(SEKUNDER_VENTETID_PÅ_PROSESSERING_AV_SØKNAD).isAfter(LocalDateTime.now())) {
-                return BehandlingTilstand.PROSESSERER;
-            }
-            LOG.info("Ingen aksjonspunkt og søknad mottatt for over {} sekunder siden, returnerer {}", SEKUNDER_VENTETID_PÅ_PROSESSERING_AV_SØKNAD,
-                BehandlingTilstand.UNDER_BEHANDLING);
-        }
         return BehandlingTilstand.UNDER_BEHANDLING;
     }
 

--- a/src/main/java/no/nav/foreldrepenger/oversikt/domene/es/SakES0.java
+++ b/src/main/java/no/nav/foreldrepenger/oversikt/domene/es/SakES0.java
@@ -58,7 +58,7 @@ public record SakES0(@JsonProperty("saksnummer") Saksnummer saksnummer,
 
     private EsÅpenBehandling tilÅpenBehandling() {
         return søknadUnderBehandling()
-            .map(s -> new EsÅpenBehandling(BehandlingTilstandUtleder.utled(aksjonspunkt(), s.mottattTidspunkt())))
+            .map(ignored -> new EsÅpenBehandling(BehandlingTilstandUtleder.utled(aksjonspunkt())))
             .orElse(null);
     }
 

--- a/src/main/java/no/nav/foreldrepenger/oversikt/domene/fp/SakFP0.java
+++ b/src/main/java/no/nav/foreldrepenger/oversikt/domene/fp/SakFP0.java
@@ -142,7 +142,7 @@ public record SakFP0(@JsonProperty("saksnummer") Saksnummer saksnummer,
                 })
                 .sorted(Comparator.comparing(UttakPeriode::fom))
                 .toList();
-            return new FpÅpenBehandling(BehandlingTilstandUtleder.utled(aksjonspunkt(), s.mottattTidspunkt()), compress(VirkedagJusterer.justerUttakPerioder(perioder)));
+            return new FpÅpenBehandling(BehandlingTilstandUtleder.utled(aksjonspunkt()), compress(VirkedagJusterer.justerUttakPerioder(perioder)));
         }).orElse(null);
     }
 

--- a/src/main/java/no/nav/foreldrepenger/oversikt/domene/svp/DtoMapper.java
+++ b/src/main/java/no/nav/foreldrepenger/oversikt/domene/svp/DtoMapper.java
@@ -33,7 +33,7 @@ final class DtoMapper {
             .map(DtoMapper::tilDto)
             .orElse(null);
         var åpenBehandling = sak.søknadUnderBehandling().map(s -> {
-            var behandlingTilstand = BehandlingTilstandUtleder.utled(sak.aksjonspunkt(), s.mottattTidspunkt());
+            var behandlingTilstand = BehandlingTilstandUtleder.utled(sak.aksjonspunkt());
             var avslutningDato = sak.familieHendelse() == null ? null : utledDato(sak.familieHendelse());
             var søknadDto = tilDto(s, avslutningDato);
             return new SvpÅpenBehandling(behandlingTilstand, søknadDto);

--- a/src/test/java/no/nav/foreldrepenger/oversikt/domene/BehandlingTilstandUtlederTest.java
+++ b/src/test/java/no/nav/foreldrepenger/oversikt/domene/BehandlingTilstandUtlederTest.java
@@ -1,7 +1,5 @@
 package no.nav.foreldrepenger.oversikt.domene;
 
-import static java.time.LocalDateTime.now;
-import static no.nav.foreldrepenger.kontrakter.fpoversikt.BehandlingTilstand.PROSESSERER;
 import static no.nav.foreldrepenger.kontrakter.fpoversikt.BehandlingTilstand.UNDER_BEHANDLING;
 import static no.nav.foreldrepenger.kontrakter.fpoversikt.BehandlingTilstand.VENT_DOKUMENTASJON;
 import static no.nav.foreldrepenger.kontrakter.fpoversikt.BehandlingTilstand.VENT_INNTEKTSMELDING;
@@ -13,105 +11,84 @@ import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDateTime;
+
 class BehandlingTilstandUtlederTest {
 
     @Test
     void ingen_ap_gir_under_behandling() {
-        var tilstand = BehandlingTilstandUtleder.utled(Set.of(), now().minusDays(1));
+        var tilstand = BehandlingTilstandUtleder.utled(Set.of());
         assertThat(tilstand).isEqualTo(UNDER_BEHANDLING);
     }
 
     @Test
     void tidlig_søknad_opprettet_ap_gir_tilstand_tidlig_opprettet() {
-        var tilstand = BehandlingTilstandUtleder.utled(Set.of(aksjonspunkt(Aksjonspunkt.Type.VENT_TIDLIG_SØKNAD)), now().minusDays(1));
+        var tilstand = BehandlingTilstandUtleder.utled(Set.of(aksjonspunkt(Aksjonspunkt.Type.VENT_TIDLIG_SØKNAD)));
         assertThat(tilstand).isEqualTo(VENT_TIDLIG_SØKNAD);
     }
 
     @Test
     void vent_på_meldekort_opprettet_ap_gir_tilstand_vent_på_meldekort() {
-        var tilstand = BehandlingTilstandUtleder.utled(Set.of(aksjonspunkt(Aksjonspunkt.Type.VENT_SISTE_AAP_ELLER_DP_MELDEKORT)), now().minusDays(1));
+        var tilstand = BehandlingTilstandUtleder.utled(Set.of(aksjonspunkt(Aksjonspunkt.Type.VENT_SISTE_AAP_ELLER_DP_MELDEKORT)));
         assertThat(tilstand).isEqualTo(VENT_MELDEKORT);
     }
 
     @Test
     void vent_på_meldekort_manuelt_opprettet_ap_gir_tilstand_vent_på_meldekort() {
         var tilstand = BehandlingTilstandUtleder.utled(
-            Set.of(aksjonspunkt(Aksjonspunkt.Type.VENT_MANUELT_SATT, Aksjonspunkt.Venteårsak.SISTE_AAP_ELLER_DP_MELDEKORT)), now().minusDays(1));
+            Set.of(aksjonspunkt(Aksjonspunkt.Type.VENT_MANUELT_SATT, Aksjonspunkt.Venteårsak.SISTE_AAP_ELLER_DP_MELDEKORT)));
         assertThat(tilstand).isEqualTo(VENT_MELDEKORT);
     }
 
     @Test
     void vent_på_meldekort_manuelt_opprettet_ap_uten_ventårsak_gir_under_behandling_tilstand() {
-        var tilstand = BehandlingTilstandUtleder.utled(Set.of(aksjonspunkt(Aksjonspunkt.Type.VENT_MANUELT_SATT, null)), now().minusDays(1));
+        var tilstand = BehandlingTilstandUtleder.utled(Set.of(aksjonspunkt(Aksjonspunkt.Type.VENT_MANUELT_SATT, null)));
         assertThat(tilstand).isEqualTo(UNDER_BEHANDLING);
     }
 
     @Test
     void vent_på_komplett_søknad_med_årsak_dok_gir_vent_på_dok_tilstand() {
         var tilstand = BehandlingTilstandUtleder.utled(
-            Set.of(aksjonspunkt(Aksjonspunkt.Type.VENT_KOMPLETT_SØKNAD, Aksjonspunkt.Venteårsak.AVVENT_DOKUMTANSJON)), now().minusDays(1));
+            Set.of(aksjonspunkt(Aksjonspunkt.Type.VENT_KOMPLETT_SØKNAD, Aksjonspunkt.Venteårsak.AVVENT_DOKUMTANSJON)));
         assertThat(tilstand).isEqualTo(VENT_DOKUMENTASJON);
     }
 
     @Test
     void vent_på_komplett_søknad_med_årsak_null_gir_under_behandling_tilstand() {
-        var tilstand = BehandlingTilstandUtleder.utled(Set.of(aksjonspunkt(Aksjonspunkt.Type.VENT_KOMPLETT_SØKNAD, null)), now().minusDays(1));
+        var tilstand = BehandlingTilstandUtleder.utled(Set.of(aksjonspunkt(Aksjonspunkt.Type.VENT_KOMPLETT_SØKNAD, null)));
         assertThat(tilstand).isEqualTo(UNDER_BEHANDLING);
     }
 
     @Test
     void vent_på_komplett_søknad_med_årsak_inntektsmelding_gir_vent_på_im_tilstand() {
         var tilstand = BehandlingTilstandUtleder.utled(
-            Set.of(aksjonspunkt(Aksjonspunkt.Type.VENT_KOMPLETT_SØKNAD, Aksjonspunkt.Venteårsak.MANGLENDE_INNTEKTSMELDING)), now().minusDays(1));
+            Set.of(aksjonspunkt(Aksjonspunkt.Type.VENT_KOMPLETT_SØKNAD, Aksjonspunkt.Venteårsak.MANGLENDE_INNTEKTSMELDING)));
         assertThat(tilstand).isEqualTo(VENT_INNTEKTSMELDING);
     }
 
     @Test
     void vent_på_etterlyst_im_med_årsak_inntektsmelding_gir_vent_på_im_tilstand() {
         var tilstand = BehandlingTilstandUtleder.utled(
-            Set.of(aksjonspunkt(Aksjonspunkt.Type.VENT_ETTERLYST_INNTEKTSMELDING, Aksjonspunkt.Venteårsak.MANGLENDE_INNTEKTSMELDING)),
-            now().minusDays(1));
+            Set.of(aksjonspunkt(Aksjonspunkt.Type.VENT_ETTERLYST_INNTEKTSMELDING, Aksjonspunkt.Venteårsak.MANGLENDE_INNTEKTSMELDING)));
         assertThat(tilstand).isEqualTo(VENT_INNTEKTSMELDING);
     }
 
     @Test
     void vent_på_etterlyst_im_med_årsak_null_gir_vent_på_im_tilstand() {
-        var tilstand = BehandlingTilstandUtleder.utled(Set.of(aksjonspunkt(Aksjonspunkt.Type.VENT_ETTERLYST_INNTEKTSMELDING, null)),
-            now().minusDays(1));
+        var tilstand = BehandlingTilstandUtleder.utled(Set.of(aksjonspunkt(Aksjonspunkt.Type.VENT_ETTERLYST_INNTEKTSMELDING, null)));
         assertThat(tilstand).isEqualTo(VENT_INNTEKTSMELDING);
     }
 
     @Test
     void vent_på_inntektsmelding_manuelt_opprettet_ap_gir_tilstand_vent_på_im() {
         var tilstand = BehandlingTilstandUtleder.utled(
-            Set.of(aksjonspunkt(Aksjonspunkt.Type.VENT_MANUELT_SATT, Aksjonspunkt.Venteårsak.MANGLENDE_INNTEKTSMELDING)), now().minusDays(1));
+            Set.of(aksjonspunkt(Aksjonspunkt.Type.VENT_MANUELT_SATT, Aksjonspunkt.Venteårsak.MANGLENDE_INNTEKTSMELDING)));
         assertThat(tilstand).isEqualTo(VENT_INNTEKTSMELDING);
     }
 
     @Test
-    void annet_aksjonspunkt_gir_under_behandling_tilstand_selv_om_søknad_mottatt_nylig() {
-        var tilstand = BehandlingTilstandUtleder.utled(Set.of(aksjonspunkt(Aksjonspunkt.Type.ANNET)), now().minusSeconds(1));
-        assertThat(tilstand).isEqualTo(UNDER_BEHANDLING);
-    }
-
-    @Test
-    void ingen_aksjonspunkt_og_søknad_mottatt_nylig_gir_prosesserer_tilstand() {
-        var søknadMottattTidspunkt = now().minusSeconds(10);
-        var tilstand = BehandlingTilstandUtleder.utled(Set.of(), søknadMottattTidspunkt);
-        assertThat(tilstand).isEqualTo(PROSESSERER);
-    }
-
-    @Test
-    void ingen_aksjonspunkt_og_søknad_mottatt_for_lenge_siden_gir_under_behandling_tilstand() {
-        var søknadMottattTidspunkt = now().minusSeconds(20);
-        var tilstand = BehandlingTilstandUtleder.utled(Set.of(), søknadMottattTidspunkt);
-        assertThat(tilstand).isEqualTo(UNDER_BEHANDLING);
-    }
-
-    @Test
-    void ingen_aksjonspunkt_og_søknad_mottatt_akkurat_15_sekunder_siden_gir_under_behandling_tilstand() {
-        var søknadMottattTidspunkt = now().minusSeconds(15);
-        var tilstand = BehandlingTilstandUtleder.utled(Set.of(), søknadMottattTidspunkt);
+    void annet_aksjonspunkt_gir_under_behandling_tilstand() {
+        var tilstand = BehandlingTilstandUtleder.utled(Set.of(aksjonspunkt(Aksjonspunkt.Type.ANNET)));
         assertThat(tilstand).isEqualTo(UNDER_BEHANDLING);
     }
 
@@ -120,7 +97,7 @@ class BehandlingTilstandUtlederTest {
     }
 
     private Aksjonspunkt aksjonspunkt(Aksjonspunkt.Type type, Aksjonspunkt.Venteårsak venteårsak) {
-        return new Aksjonspunkt(type, venteårsak, now());
+        return new Aksjonspunkt(type, venteårsak, LocalDateTime.now());
     }
 
 }


### PR DESCRIPTION
… 9.4.37

Fjerner PROSESSERER-logikk fra BehandlingTilstandUtleder: prod-guard, tidssjekk og SEKUNDER_VENTETID_PÅ_PROSESSERING_AV_SØKNAD. Tom aksjonspunkt-liste returnerer nå direkte UNDER_BEHANDLING. Oppdaterer alle kallere og tester.