### PR TITLE
Chore: Bruk topicnamestrategy som før

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/oversikt/innhenting/journalføringshendelse/JournalføringHendelseHåndterer.java
+++ b/src/main/java/no/nav/foreldrepenger/oversikt/innhenting/journalføringshendelse/JournalføringHendelseHåndterer.java
@@ -11,6 +11,7 @@ import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 
 import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
+import io.confluent.kafka.serializers.subject.TopicNameStrategy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.control.ActivateRequestContext;
 import jakarta.inject.Inject;
@@ -126,6 +127,8 @@ public class JournalføringHendelseHåndterer implements KafkaMessageHandler<Str
             return Map.of(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, schemaRegistryUrl,
                 AbstractKafkaSchemaSerDeConfig.BASIC_AUTH_CREDENTIALS_SOURCE, "USER_INFO",
                 AbstractKafkaSchemaSerDeConfig.USER_INFO_CONFIG, KafkaProperties.getAvroSchemaRegistryBasicAuth(),
+                AbstractKafkaSchemaSerDeConfig.KEY_SUBJECT_NAME_STRATEGY, TopicNameStrategy.class.getName(),
+                AbstractKafkaSchemaSerDeConfig.VALUE_SUBJECT_NAME_STRATEGY, TopicNameStrategy.class.getName(),
                 SPECIFIC_AVRO_READER_CONFIG, true);
         } else {
             return Map.of();


### PR DESCRIPTION
Unngå loggstøy etter vi tok i bruk Confluent 8.3.0 - som igjen ruller ut noe nytt som Aiven ikke kommer til å støtte.